### PR TITLE
Use new name of `openai-whisper` module, ditch simpleaudio

### DIFF
--- a/bertosito_chat.py
+++ b/bertosito_chat.py
@@ -7,11 +7,11 @@ import whisper
 import requests
 import asyncio
 import edge_tts
-import simpleaudio as sa
 import os
 import json
 from colorama import init, Fore
 from pydub import AudioSegment
+from pydub.playback import play
 from scipy.io.wavfile import write
 import sys
 
@@ -159,9 +159,7 @@ def speak_response(response_text, voice='es-MX-JorgeNeural'):
             sound.export(filename_wav, format="wav")
 
             if os.path.exists(filename_wav) and os.path.getsize(filename_wav) > 0:
-                wave_obj = sa.WaveObject.from_wave_file(filename_wav)
-                play_obj = wave_obj.play()
-                play_obj.wait_done()
+                play(sound)
                 os.remove(filename_mp3)
                 os.remove(filename_wav)
             else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 sounddevice
-whisper
+openai-whisper
 requests
 asyncio
 edge_tts
-simpleaudio
+pyaudio
 colorama
 pydub
 scipy


### PR DESCRIPTION

When trying to run the code, I ran into two errors that caused crashes:

    The whisper module didn't have a .load_model() function
    The speak_response() function caused a segfault on play_obj.wait_done()

To get it working:

    replaced the whisper module with openai-whisper
    removed simpleaudio and use pyaudio via pydub.playback.play

